### PR TITLE
[package] [mediacenter-skin-osmc] startup changes

### DIFF
--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Startup.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Startup.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<!-- startup -->
-	<onload>Skin.Reset(HideSettings)</onload>
-	<onload>ReplaceWindow($INFO[System.StartupWindow])</onload>
+	<defaultcontrol always="true">100</defaultcontrol>
+	<controls>
+		<control type="button" id="100">
+			<font>-</font>
+			<onfocus condition="!IsEmpty(Window(home).Property(walkthough_is_running))">SetFocus(101)</onfocus>
+			<onfocus condition="IsEmpty(Window(home).Property(walkthough_is_running))">ReplaceWindow($INFO[System.StartupWindow])</onfocus>
+		</control>
+		<control type="button" id="101">
+			<font>-</font>
+			<onfocus>SetFocus(100)</onfocus>
+		</control>
+	</controls>
 </window>


### PR DESCRIPTION
As discussed this checks if the walk through is running and waits until it's finished before loading the home screen.