### PR TITLE
Raise the window

### DIFF
--- a/installer/host/qt_host_installer/main.cpp
+++ b/installer/host/qt_host_installer/main.cpp
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     fontDatabase.addApplicationFont(":/assets/resources/SourceSansPro-Regular.ttf");
     MainWindow w;
     w.show();
+    w.raise();
     
     return a.exec();
 }


### PR DESCRIPTION
Calling raise() on the window is needed for it to launch in the foreground on OS X.