### PR TITLE
Fix printing the MOTD a second time

### DIFF
--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -63,7 +63,7 @@ ChallengeResponseAuthentication no
 
 X11Forwarding yes
 X11DisplayOffset 10
-PrintMotd yes
+PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
 #UseLogin no


### PR DESCRIPTION
The motd is printed two times because it's already handled by /etc/pam.d/sshd