### PR TITLE
Update udisks-glue.conf

### DIFF
--- a/package/diskmount-osmc/files/etc/udisks-glue.conf
+++ b/package/diskmount-osmc/files/etc/udisks-glue.conf
@@ -6,6 +6,6 @@ filter disks {
 
 match disks {
     automount = true
-    post_insertion_command = "udisks --mount %device_file --mount-options sync,noatime"
-    post_insertion_command = "/sbin/hdparm -S 240 %device_file"
+    automount_options = {sync,noatime}
+    post_insertion_command = "sudo /sbin/hdparm -S 240 %device_file"
 }


### PR DESCRIPTION
Fixed: mount options not applied
Fixed: dmesg error: "hdparm sending ioctl 2285 to a partition" and setting not applied, due to ioctl call from userspace