### PR TITLE
State default username and password on "Getting to the terminal" wiki page

### DIFF
--- a/wiki/pages/console
+++ b/wiki/pages/console
@@ -5,6 +5,7 @@ You can get to the console in two ways:
 	<li>Logging in via SSH using an SSH client on a Windows, Mac or Linux system</li>
 	<li>By exiting Kodi</li>
 </ul>
+The default username is osmc with the password osmc.
 </p>
 <h2>Logging in via SSH</h2>
 <p>


### PR DESCRIPTION
Feel free to change the wording but I think the default username and password should be stated.
Just saying "the passwod" or "your username and password" seems odd when the user probably won't make a conscious decision about either.