### PR TITLE
Add kernel patches to fix mmc corruption issues

### DIFF
--- a/package/kernel-osmc/patches/rbp-024-mmc-corruption-fixes.patch
+++ b/package/kernel-osmc/patches/rbp-024-mmc-corruption-fixes.patch
@@ -1,0 +1,253 @@
+From 320e1cf6110adbf7822dc12f1462b3710d07d70e Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Mon, 13 Apr 2015 23:34:50 +0100
+Subject: [PATCH] bcm2835-mmc: Add range of debug options for slowing things
+ down
+
+---
+ drivers/mmc/host/bcm2835-mmc.c | 46 ++++++++++++++++++++++++++++--------------
+ 1 file changed, 31 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/mmc/host/bcm2835-mmc.c b/drivers/mmc/host/bcm2835-mmc.c
+index 34d6167..7289402 100644
+--- a/drivers/mmc/host/bcm2835-mmc.c
++++ b/drivers/mmc/host/bcm2835-mmc.c
+@@ -75,6 +75,9 @@ pr_debug(DRIVER_NAME " [%s()]: " f, __func__, ## x)
+ #define BCM2835_VCMMU_SHIFT		(0x7E000000 - BCM2708_PERI_BASE)
+ 
+ 
++/*static */unsigned mmc_debug;
++/*static */unsigned mmc_debug2;
++
+ struct bcm2835_host {
+ 	spinlock_t				lock;
+ 
+@@ -139,15 +142,25 @@ struct bcm2835_host {
+ };
+ 
+ 
+-static inline void bcm2835_mmc_writel(struct bcm2835_host *host, u32 val, int reg)
++static inline void bcm2835_mmc_writel(struct bcm2835_host *host, u32 val, int reg, int from)
+ {
++	u32 delay;
+ 	writel(val, host->ioaddr + reg);
+ 	udelay(BCM2835_SDHCI_WRITE_DELAY(max(host->clock, MIN_FREQ)));
++
++	delay = ((mmc_debug >> 16) & 0xf) << ((mmc_debug >> 20) & 0xf);
++	if (delay && !((1<<from) & mmc_debug2))
++		udelay(delay);
+ }
+ 
+ static inline void mmc_raw_writel(struct bcm2835_host *host, u32 val, int reg)
+ {
++	u32 delay;
+ 	writel(val, host->ioaddr + reg);
++
++	delay = ((mmc_debug >> 24) & 0xf) << ((mmc_debug >> 28) & 0xf);
++	if (delay)
++		udelay(delay);
+ }
+ 
+ static inline u32 bcm2835_mmc_readl(struct bcm2835_host *host, int reg)
+@@ -167,7 +180,7 @@ static inline void bcm2835_mmc_writew(struct bcm2835_host *host, u16 val, int re
+ 	if (reg == SDHCI_TRANSFER_MODE)
+ 		host->shadow = newval;
+ 	else
+-		bcm2835_mmc_writel(host, newval, reg & ~3);
++		bcm2835_mmc_writel(host, newval, reg & ~3, 0);
+ 
+ }
+ 
+@@ -179,7 +192,7 @@ static inline void bcm2835_mmc_writeb(struct bcm2835_host *host, u8 val, int reg
+ 	u32 mask = 0xff << byte_shift;
+ 	u32 newval = (oldval & ~mask) | (val << byte_shift);
+ 
+-	bcm2835_mmc_writel(host, newval, reg & ~3);
++	bcm2835_mmc_writel(host, newval, reg & ~3, 1);
+ }
+ 
+ 
+@@ -211,7 +224,7 @@ static void bcm2835_mmc_unsignal_irqs(struct bcm2835_host *host, u32 clear)
+ 	ier &= ~clear;
+ 	/* change which requests generate IRQs - makes no difference to
+ 	   the content of SDHCI_INT_STATUS, or the need to acknowledge IRQs */
+-	bcm2835_mmc_writel(host, ier, SDHCI_SIGNAL_ENABLE);
++	bcm2835_mmc_writel(host, ier, SDHCI_SIGNAL_ENABLE, 2);
+ }
+ 
+ 
+@@ -305,8 +318,8 @@ static void bcm2835_mmc_init(struct bcm2835_host *host, int soft)
+ 		    SDHCI_INT_TIMEOUT | SDHCI_INT_DATA_END |
+ 		    SDHCI_INT_RESPONSE;
+ 
+-	bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE);
+-	bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE);
++	bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE, 3);
++	bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE, 3);
+ 
+ 	if (soft) {
+ 		/* force clock reconfiguration */
+@@ -528,8 +541,8 @@ static void bcm2835_mmc_set_transfer_irqs(struct bcm2835_host *host)
+ 	else
+ 		host->ier = (host->ier & ~dma_irqs) | pio_irqs;
+ 
+-	bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE);
+-	bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE);
++	bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE, 4);
++	bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE, 4);
+ }
+ 
+ 
+@@ -611,7 +624,7 @@ static void bcm2835_mmc_set_transfer_mode(struct bcm2835_host *host,
+ 			mode |= SDHCI_TRNS_AUTO_CMD12;
+ 		else if (host->mrq->sbc && (host->flags & SDHCI_AUTO_CMD23)) {
+ 			mode |= SDHCI_TRNS_AUTO_CMD23;
+-			bcm2835_mmc_writel(host, host->mrq->sbc->arg, SDHCI_ARGUMENT2);
++			bcm2835_mmc_writel(host, host->mrq->sbc->arg, SDHCI_ARGUMENT2, 5);
+ 		}
+ 	}
+ 
+@@ -674,7 +687,7 @@ void bcm2835_mmc_send_command(struct bcm2835_host *host, struct mmc_command *cmd
+ 
+ 	bcm2835_mmc_prepare_data(host, cmd);
+ 
+-	bcm2835_mmc_writel(host, cmd->arg, SDHCI_ARGUMENT);
++	bcm2835_mmc_writel(host, cmd->arg, SDHCI_ARGUMENT, 6);
+ 
+ 	bcm2835_mmc_set_transfer_mode(host, cmd);
+ 
+@@ -831,8 +844,8 @@ static void bcm2835_mmc_enable_sdio_irq_nolock(struct bcm2835_host *host, int en
+ 		else
+ 			host->ier &= ~SDHCI_INT_CARD_INT;
+ 
+-		bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE);
+-		bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE);
++		bcm2835_mmc_writel(host, host->ier, SDHCI_INT_ENABLE, 7);
++		bcm2835_mmc_writel(host, host->ier, SDHCI_SIGNAL_ENABLE, 7);
+ 		mmiowb();
+ 	}
+ }
+@@ -979,7 +992,7 @@ static irqreturn_t bcm2835_mmc_irq(int irq, void *dev_id)
+ 		/* Clear selected interrupts. */
+ 		mask = intmask & (SDHCI_INT_CMD_MASK | SDHCI_INT_DATA_MASK |
+ 				  SDHCI_INT_BUS_POWER);
+-		bcm2835_mmc_writel(host, mask, SDHCI_INT_STATUS);
++		bcm2835_mmc_writel(host, mask, SDHCI_INT_STATUS, 8);
+ 
+ 
+ 		if (intmask & SDHCI_INT_CMD_MASK)
+@@ -1009,7 +1022,7 @@ static irqreturn_t bcm2835_mmc_irq(int irq, void *dev_id)
+ 
+ 		if (intmask) {
+ 			unexpected |= intmask;
+-			bcm2835_mmc_writel(host, intmask, SDHCI_INT_STATUS);
++			bcm2835_mmc_writel(host, intmask, SDHCI_INT_STATUS, 9);
+ 		}
+ 
+ 		if (result == IRQ_NONE)
+@@ -1299,7 +1312,8 @@ int bcm2835_mmc_add_host(struct bcm2835_host *host)
+ 
+ 	spin_lock_init(&host->lock);
+ 
+-
++	if (mmc_debug || mmc_debug2)
++		pr_info("mmc_debug:%x mmc_debug2:%x\n", mmc_debug, mmc_debug2);
+ #ifdef FORCE_PIO
+ 	pr_info("Forcing PIO mode\n");
+ 	host->have_dma = false;
+@@ -1551,6 +1565,8 @@ static struct platform_driver bcm2835_mmc_driver = {
+ };
+ module_platform_driver(bcm2835_mmc_driver);
+ 
++module_param(mmc_debug, uint, 0644);
++module_param(mmc_debug2, uint, 0644);
+ MODULE_ALIAS("platform:mmc-bcm2835");
+ MODULE_DESCRIPTION("BCM2835 SDHCI driver");
+ MODULE_LICENSE("GPL v2");
+From 4a88fc6e40a4f4ad81265c1db49eb4ca39d9b412 Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Sat, 18 Apr 2015 17:21:12 +0100
+Subject: [PATCH] bcm2835-mmc: Default to disabling MMC_QUIRK_BLK_NO_CMD23
+
+See: https://github.com/raspberrypi/firmware/issues/397
+---
+ drivers/mmc/core/quirks.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/mmc/core/quirks.c b/drivers/mmc/core/quirks.c
+index f472082..bc3bbad 100644
+--- a/drivers/mmc/core/quirks.c
++++ b/drivers/mmc/core/quirks.c
+@@ -71,6 +71,7 @@ static const struct mmc_fixup mmc_fixup_methods[] = {
+ 
+ void mmc_fixup_device(struct mmc_card *card, const struct mmc_fixup *table)
+ {
++	extern unsigned mmc_debug;
+ 	const struct mmc_fixup *f;
+ 	u64 rev = cid_rev_card(card);
+ 
+@@ -98,6 +99,7 @@ void mmc_fixup_device(struct mmc_card *card, const struct mmc_fixup *table)
+ 	/* SDHCI on BCM2708 - bug causes a certain sequence of CMD23 operations to fail.
+ 	 * Disable this flag for all cards (fall-back to CMD25/CMD18 multi-block transfers).
+ 	 */
++	if (mmc_debug & (1<<13))
+ 	card->quirks |= MMC_QUIRK_BLK_NO_CMD23;
+ }
+ EXPORT_SYMBOL(mmc_fixup_device);
+From 2747cc0bde4ca441691260fae1e34c9ef954ccae Mon Sep 17 00:00:00 2001
+From: popcornmix <popcornmix@gmail.com>
+Date: Sat, 18 Apr 2015 17:20:14 +0100
+Subject: [PATCH] bcm2708-dmaengine: Add debug option for setting wait states
+
+---
+ drivers/dma/bcm2708-dmaengine.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/dma/bcm2708-dmaengine.c b/drivers/dma/bcm2708-dmaengine.c
+index 3f9be02..e4296e8 100644
+--- a/drivers/dma/bcm2708-dmaengine.c
++++ b/drivers/dma/bcm2708-dmaengine.c
+@@ -56,6 +56,7 @@
+ 
+ #include "virt-dma.h"
+ 
++static unsigned dma_debug;
+ 
+ struct bcm2835_dmadev {
+ 	struct dma_device ddev;
+@@ -583,6 +584,7 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_slave_sg(
+ 		uint32_t len = sg_dma_len(sgent);
+ 
+ 		for (j = 0; j < len; j += max_size) {
++			u32 waits = SDHCI_BCM_DMA_WAITS;
+ 			struct bcm2835_dma_cb *control_block =
+ 				&d->control_block_base[i+splitct];
+ 
+@@ -600,7 +602,9 @@ static struct dma_async_tx_descriptor *bcm2835_dma_prep_slave_sg(
+ 			}
+ 
+ 			/* Common part */
+-			control_block->info |= BCM2835_DMA_WAITS(SDHCI_BCM_DMA_WAITS);
++			if ((dma_debug >> 0) & 0x1f)
++				waits = (dma_debug >> 0) & 0x1f;
++			control_block->info |= BCM2835_DMA_WAITS(waits);
+ 			control_block->info |= BCM2835_DMA_WAIT_RESP;
+ 
+ 			/* Enable  */
+@@ -969,6 +973,8 @@ static int bcm2835_dma_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	dev_info(&pdev->dev, "Load BCM2835 DMA engine driver\n");
++	if (dma_debug)
++		dev_info(&pdev->dev, "dma_debug:%x\n", dma_debug);
+ 
+ 	return 0;
+ 
+@@ -1045,6 +1051,7 @@ module_platform_driver(bcm2835_dma_driver);
+ 
+ #endif
+ 
++module_param(dma_debug, uint, 0644);
+ MODULE_ALIAS("platform:bcm2835-dma");
+ MODULE_DESCRIPTION("BCM2835 DMA engine driver");
+ MODULE_AUTHOR("Florian Meier <florian.meier@koalo.de>");


### PR DESCRIPTION
Hi,

It's a patch from https://github.com/raspberrypi/linux to fix https://github.com/raspberrypi/firmware/issues/397

I tested those changes on my RBP1 and it seems to work with my Samsung EVO 16GB.
Before, I had corruption (or failed boot due to i/o error) every two or three boot.

BTW, what do you use about the build environment ? I have some issues with xargs (argument line too long) on Debian Jessie during the cross compilation.