### PR TITLE
allow Nano to be replaced with any other editor

### DIFF
--- a/package/rbp2-device-osmc/files/DEBIAN/control
+++ b/package/rbp2-device-osmc/files/DEBIAN/control
@@ -3,7 +3,7 @@ Package: rbp2-device-osmc
 Version: 1.1.0
 Section: metapackages
 Essential: No
-Depends: base-files-osmc, busybox, systemd, systemd-sysv, perftune-osmc, armv7-irqbalance-osmc, sysctl-osmc, rbp2-ftr-osmc, diskmount-osmc, apt-utils, sudo, less, module-init-tools, armv7-network-osmc, locales, dialog, nano, rbp-bootloader-osmc, armv7-splash-osmc, rbp-userland-osmc, armv7-remote-osmc, fake-hwclock, rbp2-mediacenter-osmc, rbp2-kernel-osmc
+Depends: base-files-osmc, busybox, systemd, systemd-sysv, perftune-osmc, armv7-irqbalance-osmc, sysctl-osmc, rbp2-ftr-osmc, diskmount-osmc, apt-utils, sudo, less, module-init-tools, armv7-network-osmc, locales, dialog, nano | editor, rbp-bootloader-osmc, armv7-splash-osmc, rbp-userland-osmc, armv7-remote-osmc, fake-hwclock, rbp2-mediacenter-osmc, rbp2-kernel-osmc
 Priority: required
 Architecture: armhf
 Maintainer: Sam G Nazarko <email@samnazarko.co.uk>


### PR DESCRIPTION
Previously, removal of the Nano editor in favour of other editors would force removal of this metapackage, causing subsequent upgrade issues.

[The inclusion of Nano as a dependency is only done to ensure that an editor is installed during the build process.](https://discourse.osmc.tv/t/rbp2-device-osmc-package-depends-on-nano-not-editor/4311/4)  Nano, specifically, is not used by anything but a user.

With this change, Nano is still provided by default but users are able to remove it in favour of other editors if desired.