### PR TITLE
[package] [mediacenter-addon-osmc] WiFi list selection brighter

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui.xml
@@ -987,7 +987,7 @@
                 <posy>75</posy>
                 <width>680</width>
                 <height>850</height>
-                <texture>TextShade.png</texture>
+                <!--Darkness <texture>TextShade.png</texture>-->
             </control>
             <!-- wifi list -->
             <control id="5000" type="list">

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui_720.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui_720.xml
@@ -987,7 +987,7 @@
                 <posy>75</posy>
                 <width>680</width>
                 <height>850</height>
-                <texture>TextShade.png</texture>
+                <!--Darkness <texture>TextShade.png</texture>-->
             </control>
             <!-- wifi list -->
             <control id="5000" type="list">


### PR DESCRIPTION
Simple change to network plugin to make the wifi list selection brighter. Removes background box texture.