### PR TITLE
Fix broken buttons (volume down & pictures) on Hauppauge 350 remote.

### DIFF
--- a/package/remote-osmc/files/etc/lirc/hauppage45-pvr350-lircd.conf
+++ b/package/remote-osmc/files/etc/lirc/hauppage45-pvr350-lircd.conf
@@ -24,7 +24,7 @@ begin remote
           KEY_BACK                 0x179F
           KEY_MENU                 0x178D
           KEY_VOLUMEUP             0x1790
-          KEY_VOLUMEDOWN           0x17B7
+          KEY_VOLUMEDOWN           0x1791
           KEY_MUTE                 0x178F
           KEY_CHANNELUP            0x17A0
           KEY_CHANNELDOWN          0x17A1
@@ -52,7 +52,7 @@ begin remote
           KEY_BLUE                 0x17A9
           KEY_GOTO                 0x17BB
           KEY_AUDIO                0x1799
-          KEY_IMAGES               0x179A
+          KEY_CAMERA               0x179A
           KEY_EPG                  0x179B
           KEY_RADIO                0x178C
           KEY_NUMERIC_POUND        0x178E

--- a/package/remote-osmc/files/etc/lirc/lircd-full.conf
+++ b/package/remote-osmc/files/etc/lirc/lircd-full.conf
@@ -697,7 +697,7 @@ begin remote
           KEY_BACK                 0x179F
           KEY_MENU                 0x178D
           KEY_VOLUMEUP             0x1790
-          KEY_VOLUMEDOWN           0x17B7
+          KEY_VOLUMEDOWN           0x1791
           KEY_MUTE                 0x178F
           KEY_CHANNELUP            0x17A0
           KEY_CHANNELDOWN          0x17A1
@@ -725,7 +725,7 @@ begin remote
           KEY_BLUE                 0x17A9
           KEY_GOTO                 0x17BB
           KEY_AUDIO                0x1799
-          KEY_IMAGES               0x179A
+          KEY_CAMERA               0x179A
           KEY_EPG                  0x179B
           KEY_RADIO                0x178C
           KEY_NUMERIC_POUND        0x178E


### PR DESCRIPTION
The "volume down" and "pictures" buttons on my Hauppauge 350 remote weren't working. After this small correction they're doing what they're supposed to.