### PR TITLE
[installer][host] make Textfield for WIFI Key a real Password-Field

### DIFF
--- a/installer/host/qt_host_installer/wifinetworksetup.ui
+++ b/installer/host/qt_host_installer/wifinetworksetup.ui
@@ -206,6 +206,12 @@ background: rgb(240, 240, 240, 0);
 background: rgb(240, 240, 240, 0);
 </string>
    </property>
+   <property name="inputMethodHints">
+    <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
+   </property>
+   <property name="echoMode">
+    <enum>QLineEdit::Password</enum>
+   </property>
   </widget>
   <widget class="QLabel" name="keyLabel">
    <property name="geometry">


### PR DESCRIPTION
inputMethodHints have been set automagically by Creator to reflect the password property. See http://doc.qt.io/qt-5/qt.html#InputMethodHint-enum for details on why they are relevant.
For example, you want Qt::ImhNoPredictiveText to avoid dictionary lookups - no use to have your password searched for in cleartext around places :)