### PR TITLE
[installer][host] make Textfield for WIFI Key a real Password-Field.

### DIFF
--- a/installer/host/qt_host_installer/qt_host_installer.pro
+++ b/installer/host/qt_host_installer/qt_host_installer.pro
@@ -91,7 +91,7 @@ FORMS    += mainwindow.ui \
     extractprogress.ui \
     successdialog.ui
 
-VERSION = 113
+VERSION = 114
 
 TRANSLATIONS = osmc.ts \
     osmc_da.ts \

--- a/installer/host/qt_host_installer/utils.h
+++ b/installer/host/qt_host_installer/utils.h
@@ -11,7 +11,7 @@
 #include "supporteddevice.h"
 #include <QList>
 
-#define BUILD_NUMBER 113
+#define BUILD_NUMBER 114
 
 namespace utils
 {

--- a/installer/host/qt_host_installer/wifinetworksetup.ui
+++ b/installer/host/qt_host_installer/wifinetworksetup.ui
@@ -206,6 +206,12 @@ background: rgb(240, 240, 240, 0);
 background: rgb(240, 240, 240, 0);
 </string>
    </property>
+   <property name="inputMethodHints">
+    <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
+   </property>
+   <property name="echoMode">
+    <enum>QLineEdit::Password</enum>
+   </property>
   </widget>
   <widget class="QLabel" name="keyLabel">
    <property name="geometry">


### PR DESCRIPTION
inputMethodHints have been set automagically by Creator to reflect the password property. See http://doc.qt.io/qt-5/qt.html#InputMethodHint-enum for details on why they are relevant.
For example, you want Qt::ImhNoPredictiveText to avoid dictionary lookups - no use to have your password searched for in cleartext around places :)